### PR TITLE
[Bug] Temporary fix for dirty read-write issue

### DIFF
--- a/clients/cpp/client.cpp
+++ b/clients/cpp/client.cpp
@@ -43,7 +43,7 @@ int get_state() {
 }
 
 void send_move(int move) {
-	std::string s = "sendmove " + std::to_string(move);
+	std::string s = "sendmove " + std::to_string(move) + " ";
 	send(socket_id, s.c_str(), s.length(), 0);
 }
 

--- a/server.php
+++ b/server.php
@@ -163,7 +163,7 @@
 		$command_parts = explode(" ", $command);
 
 		// perform actions based on command and log results
-		if($command_parts[0] == "getstate") {
+		if($command_parts[0] == "getstate" || (count($command_parts) >=2 && $command_parts[2] == "getstate")) {
 			// send message
 			send_message($connections[$current_player], "$num_stones\n", $is_websocket[$current_player]);
 			
@@ -177,7 +177,7 @@
 			}
 			echo("\n");
 			echo("[INFO] Move time remaining: $time_remaining[$current_player] microseconds\n\n");
-		} else if($command_parts[0] == "sendmove" && $cards[$current_player][$command_parts[1]]) {
+		} if($command_parts[0] == "sendmove" && $cards[$current_player][$command_parts[1]]) {
 			// apply timer
 			$time_remaining[$current_player] -= microtime(true) - $time_start;
 


### PR DESCRIPTION
- Client-server communication is being done through sockets.
- The socket is supposed to block calls from one client when the other client is writing to it. However, in some edge cases, this is not being observed.

This is an intermittent issue and is difficult to reproduce.

This commit fixes the same by processing both the getstate command and the sendmove command by different clients.

See issue: https://github.com/HUNTINGHOUND/cardnimarchitect/issues/1